### PR TITLE
Add permission node for using jukeboxes, fix worldguard integration

### DIFF
--- a/src/main/java/me/spartacus04/jext/integrations/Integration.kt
+++ b/src/main/java/me/spartacus04/jext/integrations/Integration.kt
@@ -18,12 +18,12 @@ interface Integration {
      * @param player The player parameter represents the player who is trying to interact with the jukebox GUI.
      * @param block The "block" parameter represents the jukebox block that the player is trying to interact with.
      */
-    fun hasJukeboxGuiAccess(player: Player, block: Block): Boolean
+    fun hasJukeboxGuiAccess(player: Player, block: Block): Boolean?
     /**
      * The function checks if a player can interact with a jukebox block.
      *
      * @param player The player parameter represents the player who wants to interact with the jukebox.
      * @param block The "block" parameter represents the jukebox block that the player is trying to interact with.
      */
-    fun hasJukeboxAccess(player: Player, block: Block): Boolean
+    fun hasJukeboxAccess(player: Player, block: Block): Boolean?
 }

--- a/src/main/java/me/spartacus04/jext/integrations/IntegrationsManager.kt
+++ b/src/main/java/me/spartacus04/jext/integrations/IntegrationsManager.kt
@@ -5,6 +5,7 @@ import me.spartacus04.jext.language.LanguageManager.Companion.GEYSER_RELOAD
 import org.bukkit.Bukkit
 import org.bukkit.block.Block
 import org.bukkit.entity.Player
+import javax.annotation.Nullable
 
 class IntegrationsManager {
     private val integrations = ArrayList<Integration>()
@@ -19,9 +20,29 @@ class IntegrationsManager {
         integrations.forEach { registerIntegration(it) }
     }
 
-    fun hasJukeboxAccess(player: Player, block: Block): Boolean = integrations.all { it.hasJukeboxAccess(player, block) }
+    fun hasJukeboxAccess(player: Player, block: Block): Boolean? {
+        for(integration in integrations){
+            val state = integration.hasJukeboxAccess(player, block)
+            return when(state){
+                true->true
+                false->continue
+                null->null
+            }
+        }
+        return false
+    }
 
-    fun hasJukeboxGuiAccess(player: Player, block: Block): Boolean = integrations.all { it.hasJukeboxGuiAccess(player, block) }
+    fun hasJukeboxGuiAccess(player: Player, block: Block): Boolean? {
+        for(integration in integrations){
+            val state = integration.hasJukeboxGuiAccess(player, block)
+            return when(state){
+                true->true
+                false->continue
+                null->null
+            }
+        }
+        return false
+    }
 
     fun reloadDefaultIntegrations() {
         integrations.removeIf { it.id == "worldguard" || it.id == "griefprevention" }

--- a/src/main/java/me/spartacus04/jext/integrations/WorldGuardIntegration.kt
+++ b/src/main/java/me/spartacus04/jext/integrations/WorldGuardIntegration.kt
@@ -15,19 +15,25 @@ internal class WorldGuardIntegration : Integration {
         Flags.CHEST_ACCESS
     }
 
-    override fun hasJukeboxAccess(player: Player, block: Block): Boolean = canInteract(player, block, Flags.CHEST_ACCESS)
+    override fun hasJukeboxAccess(player: Player, block: Block): Boolean? = canInteract(player, block, Flags.CHEST_ACCESS)
 
-    override fun hasJukeboxGuiAccess(player: Player, block: Block): Boolean = canInteract(player, block, Flags.BUILD, Flags.INTERACT, Flags.USE)
+    override fun hasJukeboxGuiAccess(player: Player, block: Block): Boolean? = canInteract(player, block, Flags.BUILD, Flags.INTERACT, Flags.USE)
 
-    private fun canInteract(player: Player, block: Block, vararg flags: StateFlag) : Boolean {
+    private fun canInteract(player: Player, block: Block, vararg flags: StateFlag) : Boolean? {
         val wgPlayer = WorldGuardPlugin.inst().wrapPlayer(player)
 
         if(WorldGuard.getInstance().platform.sessionManager.hasBypass(wgPlayer, wgPlayer.world)) return true
 
         val containerQuery = WorldGuard.getInstance().platform.regionContainer.createQuery()
 
-        return flags.any {
-            containerQuery.testState(BukkitAdapter.adapt(block.location), wgPlayer, it)
+        for(flag in flags) {
+            val state = containerQuery.queryState(BukkitAdapter.adapt(block.location), wgPlayer, flag)
+            return when(state) {
+                StateFlag.State.ALLOW -> true
+                StateFlag.State.DENY -> continue
+                null -> null
+            }
         }
+        return false
     }
 }

--- a/src/main/java/me/spartacus04/jext/listeners/JukeboxClickEvent.kt
+++ b/src/main/java/me/spartacus04/jext/listeners/JukeboxClickEvent.kt
@@ -31,18 +31,10 @@ internal class JukeboxClickEvent : JextListener() {
 
     private fun defaultBehaviour(event: PlayerInteractEvent, block: Block) {
         if(INTEGRATIONS.hasJukeboxAccess(event.player, block)==false) {
-            event.player.sendMessage("Missing flag")
             event.isCancelled = true
             return
         }
-        val t = if(event.player.isPermissionSet("jext.notifyupdate")) "true" else "false"
-        event.player.sendMessage(t);
-        event.player.sendMessage(if(event.player.isPermissionSet("jext.usejukebox")) "true" else "false")
-        if(!(event.player.isPermissionSet("jext.usejukebox")||event.player.isOp)){
-            for(perm in event.player.effectivePermissions){
-                event.player.sendMessage(perm.permission)
-            }
-            event.player.sendMessage("Missing permission")
+        if(!(event.player.hasPermission("jext.usejukebox")||event.player.isOp)){
             event.isCancelled = true
             return
         }
@@ -67,11 +59,9 @@ internal class JukeboxClickEvent : JextListener() {
     private fun jukeboxGui(event: PlayerInteractEvent, block: Block) {
         event.isCancelled = true
         if(INTEGRATIONS.hasJukeboxGuiAccess(event.player, block)==false) {
-            event.player.sendMessage("Missing flag")
             return
         }
         if(!(event.player.hasPermission("jext.usejukebox")||event.player.isOp)){
-            event.player.sendMessage("Missing permission")
             return
         }
 

--- a/src/main/java/me/spartacus04/jext/listeners/JukeboxClickEvent.kt
+++ b/src/main/java/me/spartacus04/jext/listeners/JukeboxClickEvent.kt
@@ -30,9 +30,21 @@ internal class JukeboxClickEvent : JextListener() {
     }
 
     private fun defaultBehaviour(event: PlayerInteractEvent, block: Block) {
-        if(!INTEGRATIONS.hasJukeboxAccess(event.player, block)) {
-             event.isCancelled = true
-             return
+        if(INTEGRATIONS.hasJukeboxAccess(event.player, block)==false) {
+            event.player.sendMessage("Missing flag")
+            event.isCancelled = true
+            return
+        }
+        val t = if(event.player.hasPermission("jext.notifyupdate")) "true" else "false"
+        event.player.sendMessage(t);
+        event.player.sendMessage(if(event.player.hasPermission("jext.usejukebox")) "true" else "false")
+        if(!(event.player.hasPermission("jext.usejukebox")||event.player.isOp)){
+            for(perm in event.player.effectivePermissions){
+                event.player.sendMessage(perm.permission)
+            }
+            event.player.sendMessage("Missing permission")
+            event.isCancelled = true
+            return
         }
 
         val state = block.state as? Jukebox ?: return
@@ -54,8 +66,14 @@ internal class JukeboxClickEvent : JextListener() {
 
     private fun jukeboxGui(event: PlayerInteractEvent, block: Block) {
         event.isCancelled = true
-
-        if(!INTEGRATIONS.hasJukeboxGuiAccess(event.player, block)) return
+        if(INTEGRATIONS.hasJukeboxGuiAccess(event.player, block)==false) {
+            event.player.sendMessage("Missing flag")
+            return
+        }
+        if(!(event.player.hasPermission("jext.usejukebox")||event.player.isOp)){
+            event.player.sendMessage("Missing permission")
+            return
+        }
 
         JukeboxGui(event.player, block)
     }

--- a/src/main/java/me/spartacus04/jext/listeners/JukeboxClickEvent.kt
+++ b/src/main/java/me/spartacus04/jext/listeners/JukeboxClickEvent.kt
@@ -35,10 +35,10 @@ internal class JukeboxClickEvent : JextListener() {
             event.isCancelled = true
             return
         }
-        val t = if(event.player.hasPermission("jext.notifyupdate")) "true" else "false"
+        val t = if(event.player.isPermissionSet("jext.notifyupdate")) "true" else "false"
         event.player.sendMessage(t);
-        event.player.sendMessage(if(event.player.hasPermission("jext.usejukebox")) "true" else "false")
-        if(!(event.player.hasPermission("jext.usejukebox")||event.player.isOp)){
+        event.player.sendMessage(if(event.player.isPermissionSet("jext.usejukebox")) "true" else "false")
+        if(!(event.player.isPermissionSet("jext.usejukebox")||event.player.isOp)){
             for(perm in event.player.effectivePermissions){
                 event.player.sendMessage(perm.permission)
             }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -73,8 +73,8 @@ permissions:
       jext.fragment.give: true
       jext.notifyupdate: true
       jext.webui: true
-      jext.admingui: true
       jext.usejukebox: true
+      jext.admingui: true
   jext.disc:
     description: Allows player to access all custom disc.
     default: op
@@ -108,8 +108,8 @@ permissions:
   jext.webui:
     description: Allows player to access webui
     default: op
-  jext.admingui:
-    description: Allows player to access admin gui
   jext.usejukebox:
     description: Allows player to use jukeboxes.
     default: op
+  jext.admingui:
+    description: Allows player to access admin gui

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -74,6 +74,7 @@ permissions:
       jext.notifyupdate: true
       jext.webui: true
       jext.admingui: true
+      jext.usejukebox: true
   jext.disc:
     description: Allows player to access all custom disc.
     default: op
@@ -109,3 +110,6 @@ permissions:
     default: op
   jext.admingui:
     description: Allows player to access admin gui
+  jext.usejukebox:
+    description: Allows player to use jukeboxes.
+    default: op


### PR DESCRIPTION
Addresses the following issue/feature request by adding the requested permission node:
- #285

Addresses the fact that the WorldGuard integration does not account for unset flags that don't have a default permission (CHEST_ACCESS does not have a default value when unset, meaning by default players cannot use jukeboxes.)
This is done via altering the flag check to allow returning `null`, and explicitly check that the returned result is equal to `false`.