### PR TITLE
1.21.1 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     }
 
     implementation("org.bstats:bstats-bukkit:3.0.2")
-    implementation("io.github.bananapuncher714:nbteditor:7.19.2")
+    implementation("io.github.bananapuncher714:nbteditor:7.19.5")
     implementation("xyz.xenondevs.invui:invui:1.32")
     implementation("xyz.xenondevs.invui:invui-kotlin:1.32")
     implementation("com.google.code.gson:gson:2.11.0")


### PR DESCRIPTION
This PR updates the NBTEditor dependency, which is necessary for 1.21.
It is tested with PaperMC 1.21.1 and it works fine.