### PR TITLE
Fix OpenInv incompatibility

### DIFF
--- a/src/main/java/me/spartacus04/jext/listeners/DiscUpdateEvent.kt
+++ b/src/main/java/me/spartacus04/jext/listeners/DiscUpdateEvent.kt
@@ -28,7 +28,7 @@ internal class DiscUpdateEvent : JextListener() {
 
     private fun updateInventory(inv: Inventory) {
         val contents = inv.contents
-        inv.contents.forEachIndexed { i, it ->
+        contents.forEachIndexed { i, it ->
             if (it != null) {
                 contents[i] = updateItem(it)
             }

--- a/src/main/java/me/spartacus04/jext/listeners/DiscUpdateEvent.kt
+++ b/src/main/java/me/spartacus04/jext/listeners/DiscUpdateEvent.kt
@@ -27,11 +27,13 @@ internal class DiscUpdateEvent : JextListener() {
     }
 
     private fun updateInventory(inv: Inventory) {
+        val contents = inv.contents
         inv.contents.forEachIndexed { i, it ->
             if (it != null) {
-                inv.setItem(i, updateItem(it))
+                contents[i] = updateItem(it)
             }
         }
+        inv.contents = contents
     }
 
     private fun updateItem(itemStack: ItemStack) : ItemStack {


### PR DESCRIPTION
As detailed in https://github.com/Jikoo/OpenInv/issues/291#issuecomment-2668903351, OpenInv uses a bit of horrible hackery to make sorting plugins that don't check what they're sorting (or worse, do check and assume slot numbers) less aggressively incompatible. As a result, its inventories return different slots for get/set(Storage)Contents from those accessed by get/setItem. Using a mix of these methods causes items to be reordered.
Because JEXT also ignores null slots, the items that would have been replaced by a null item are not wiped out, resulting in duplications rather than just jumbling.

Closes #544 