### PR TITLE
fix: /jext subcommand without args fix

### DIFF
--- a/src/main/java/me/spartacus04/jext/commands/executors/ExecutorMain.kt
+++ b/src/main/java/me/spartacus04/jext/commands/executors/ExecutorMain.kt
@@ -27,7 +27,7 @@ internal class ExecutorMain : ExecutorAdapter("jext") {
 
         val subcommand = commandRegistry.find { it.subCommandString == args[0] } ?: return
 
-        Bukkit.dispatchCommand(sender, "${subcommand.commandString} ${subArgs.joinToString(separator = " ")}")
+        Bukkit.dispatchCommand(sender, "${subcommand.commandString} ${subArgs.joinToString(separator = " ")}".trim())
     }
 
     override fun onTabComplete(


### PR DESCRIPTION
Without this fix, run `/jext admingui`
You'll get an error

Instead, run `/jext admingui asdasd`
It works! (with any argument)

This just trims the dispatchCommand call if no args are provided.
There's probably a better way to do this, I don't think all the individual commands are necessary. Either way this solves the error