### PR TITLE
On version 1.21.8, there was an error:

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     }
 
     implementation("org.bstats:bstats-bukkit:3.1.0")
-    implementation("io.github.bananapuncher714:nbteditor:7.19.9")
+    implementation("io.github.bananapuncher714:nbteditor:7.19.10")
     implementation("xyz.xenondevs.invui:invui:1.46")
     implementation("xyz.xenondevs.invui:invui-kotlin:1.46")
     implementation("com.google.code.gson:gson:2.13.1")


### PR DESCRIPTION
[01:01:34 ERROR]: Could not pass event PlayerInteractEvent to JukeboxExtendedReborn vdev java.lang.NoClassDefFoundError: Could not initialize class me.spartacus04.jext.dependencies.jext-reborn.nbteditor.NBTEditor
    at JEXT-Reborn_dev-shadowed.jar/me.spartacus04.jext.discs.DiscManager.mergedStop(DiscManager.kt:169) ~[JEXT-Reborn_dev-shadowed.jar:?]
    ...
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3 [in thread "Server thread"]
    at JEXT-Reborn_dev-shadowed.jar/me.spartacus04.jext.dependencies.jext-reborn.nbteditor.NBTEditor.<clinit>(NBTEditor.java:51) ~[JEXT-Reborn_dev-shadowed.jar:?]
    ...
I updated NBTEditor to the latest version 7.19.10, and after that the plugin started working correctly.
Please update the plugin version so everyone can use it.